### PR TITLE
Update 9 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.AzureIotHub.nuspec
+++ b/MakoIoT.Device.Services.AzureIotHub.nuspec
@@ -17,21 +17,21 @@
     <description>AzureIoTHub bus provider for MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot azure iot azureiothub</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.38.18612" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.39.3768" />
       <dependency id="nanoFramework.Azure.Devices.Client" version="1.2.12" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.1" />
       <dependency id="nanoFramework.Json" version="2.2.101" />
       <dependency id="nanoFramework.Logging" version="1.1.63" />
-      <dependency id="nanoFramework.M2Mqtt" version="5.1.101" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.6" />
-      <dependency id="nanoFramework.Runtime.Native" version="1.6.6" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.18" />
+      <dependency id="nanoFramework.M2Mqtt" version="5.1.103" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.15" />
+      <dependency id="nanoFramework.Runtime.Native" version="1.6.12" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.31" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.38" />
       <dependency id="nanoFramework.System.Net" version="1.10.62" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.106" />
-      <dependency id="nanoFramework.System.Text" version="1.2.37" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.19" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.108" />
+      <dependency id="nanoFramework.System.Text" version="1.2.54" />
+      <dependency id="nanoFramework.System.Threading" version="1.1.32" />
     </dependencies>
   </metadata>
   <files>

--- a/src/MakoIoT.Device.Services.AzureIotHub/MakoIoT.Device.Services.AzureIotHub.nfproj
+++ b/src/MakoIoT.Device.Services.AzureIotHub/MakoIoT.Device.Services.AzureIotHub.nfproj
@@ -24,11 +24,13 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="MakoIoT.Device.Services.Interface">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.38.18612\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.39.3768\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Azure.Devices.Client, Version=1.2.12.6072, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Azure.Devices.Client.1.2.12\lib\nanoFramework.Azure.Devices.Client.dll</HintPath>
@@ -48,25 +50,29 @@
     <Reference Include="nanoFramework.Logging">
       <HintPath>..\..\packages\nanoFramework.Logging.1.1.63\lib\nanoFramework.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.101.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.101\lib\nanoFramework.M2Mqtt.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.103.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.103\lib\nanoFramework.M2Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.M2Mqtt.Core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.101\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.103\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.6\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.15\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Native">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.6.6\lib\nanoFramework.Runtime.Native.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Native, Version=1.6.12.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.6.12\lib\nanoFramework.Runtime.Native.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.31\lib\nanoFramework.System.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Text">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.2.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Streams">
       <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.38\lib\System.IO.Streams.dll</HintPath>
@@ -75,12 +81,13 @@
       <HintPath>..\..\packages\nanoFramework.System.Net.1.10.62\lib\System.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.106.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.106\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.108.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.108\lib\System.Net.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Threading">
-      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.19\lib\System.Threading.dll</HintPath>
+    <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.32\lib\System.Threading.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MakoIoT.Device.Services.AzureIotHub/packages.config
+++ b/src/MakoIoT.Device.Services.AzureIotHub/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.38.18612" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.39.3768" targetFramework="netnano1.0" />
   <package id="nanoFramework.Azure.Devices.Client" version="1.2.12" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.101" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />
-  <package id="nanoFramework.M2Mqtt" version="5.1.101" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Native" version="1.6.6" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.M2Mqtt" version="5.1.103" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Native" version="1.6.12" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.10.62" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.106" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Threading" version="1.1.19" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.108" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
 </packages>


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.38.18612 to 1.0.39.3768</br>Bumps nanoFramework.CoreLibrary from 1.14.2 to 1.15.5</br>Bumps nanoFramework.M2Mqtt from 5.1.101 to 5.1.103</br>Bumps nanoFramework.Runtime.Events from 1.11.6 to 1.11.15</br>Bumps nanoFramework.Runtime.Native from 1.6.6 to 1.6.12</br>Bumps nanoFramework.System.Collections from 1.5.18 to 1.5.31</br>Bumps nanoFramework.System.Net.Http from 1.5.106 to 1.5.108</br>Bumps nanoFramework.System.Text from 1.2.37 to 1.2.54</br>Bumps nanoFramework.System.Threading from 1.1.19 to 1.1.32</br>
[version update]

### :warning: This is an automated update. :warning:
