### PR TITLE
Add logging for AzureIoT message publishing

### DIFF
--- a/src/MakoIoT.Device.Services.AzureIotHub/AzureIotHubCommunicationService.cs
+++ b/src/MakoIoT.Device.Services.AzureIotHub/AzureIotHubCommunicationService.cs
@@ -87,6 +87,7 @@ namespace MakoIoT.Device.Services.AzureIotHub
 
         public void Publish(string messageString, string messageType)
         {
+            _logger.Information($"AzureIoT publishing message");
             var isReceived = _client.SendMessage(messageString, null, new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token);
             if (!isReceived)
             {


### PR DESCRIPTION
A logging information line has been added to the `Publish` method in `AzureIotHubCommunicationService.cs`. This will allow visibility of when the AzureIoT is publishing messages, supporting debugging and monitoring purposes.