### PR TITLE
Update 3 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.AzureIotHub.nuspec
+++ b/MakoIoT.Device.Services.AzureIotHub.nuspec
@@ -18,16 +18,16 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot azure iot azureiothub</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.45.4694" />
-      <dependency id="nanoFramework.Azure.Devices.Client" version="1.2.23" />
+      <dependency id="nanoFramework.Azure.Devices.Client" version="1.2.25" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
       <dependency id="nanoFramework.Json" version="2.2.103" />
-      <dependency id="nanoFramework.M2Mqtt" version="5.1.112" />
+      <dependency id="nanoFramework.M2Mqtt" version="5.1.114" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.15" />
       <dependency id="nanoFramework.Runtime.Native" version="1.6.12" />
       <dependency id="nanoFramework.System.Collections" version="1.5.31" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.52" />
-      <dependency id="nanoFramework.System.Net" version="1.10.68" />
+      <dependency id="nanoFramework.System.Net" version="1.10.70" />
       <dependency id="nanoFramework.System.Net.Http" version="1.5.118" />
       <dependency id="nanoFramework.System.Text" version="1.2.54" />
       <dependency id="nanoFramework.System.Threading" version="1.1.32" />

--- a/src/MakoIoT.Device.Services.AzureIotHub/MakoIoT.Device.Services.AzureIotHub.nfproj
+++ b/src/MakoIoT.Device.Services.AzureIotHub/MakoIoT.Device.Services.AzureIotHub.nfproj
@@ -33,8 +33,8 @@
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Azure.Devices.Client, Version=1.2.23.5218, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Azure.Devices.Client.1.2.23\lib\nanoFramework.Azure.Devices.Client.dll</HintPath>
+    <Reference Include="nanoFramework.Azure.Devices.Client, Version=1.2.25.19328, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Azure.Devices.Client.1.2.25\lib\nanoFramework.Azure.Devices.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -45,12 +45,12 @@
       <HintPath>..\..\packages\nanoFramework.Json.2.2.103\lib\nanoFramework.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.112.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.112\lib\nanoFramework.M2Mqtt.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.114.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.114\lib\nanoFramework.M2Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.M2Mqtt.Core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.112\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.114\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -73,8 +73,8 @@
       <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.52\lib\System.IO.Streams.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.10.68.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.68\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.10.70.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.70\lib\System.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http, Version=1.5.118.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.AzureIotHub/packages.config
+++ b/src/MakoIoT.Device.Services.AzureIotHub/packages.config
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.Interface" version="1.0.45.4694" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Azure.Devices.Client" version="1.2.23" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Azure.Devices.Client" version="1.2.25" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.103" targetFramework="netnano1.0" />
-  <package id="nanoFramework.M2Mqtt" version="5.1.112" targetFramework="netnano1.0" />
+  <package id="nanoFramework.M2Mqtt" version="5.1.114" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.6.12" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.52" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.10.68" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.10.70" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net.Http" version="1.5.118" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps nanoFramework.Azure.Devices.Client from 1.2.23 to 1.2.25</br>Bumps nanoFramework.M2Mqtt from 5.1.112 to 5.1.114</br>Bumps nanoFramework.System.Net from 1.10.68 to 1.10.70</br>
[version update]

### :warning: This is an automated update. :warning:
