### PR TITLE
Adjust AzureIotHubCommunicationService visibility and error handling

### DIFF
--- a/src/MakoIoT.Device.Services.AzureIotHub/AzureIotHubCommunicationService.cs
+++ b/src/MakoIoT.Device.Services.AzureIotHub/AzureIotHubCommunicationService.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 namespace MakoIoT.Device.Services.AzureIotHub
 {
-    internal sealed class AzureIotHubCommunicationService : ICommunicationService
+    public sealed class AzureIotHubCommunicationService : ICommunicationService
     {
         private readonly INetworkProvider _networkProvider;
         private readonly ILog _logger;
@@ -57,10 +57,12 @@ namespace MakoIoT.Device.Services.AzureIotHub
                 var mqttConnectResult = _client.Open();
                 if (!_client.IsConnected)
                 {
-                    _logger.Error($"Could not connect to AzureIoT. Broker returned {mqttConnectResult}");
+                    var message = $"Could not connect to AzureIoT. Broker returned {mqttConnectResult}";
+                    _logger.Error(message);
+                    throw new Exception(message);
                 }
             }
-            catch(Exception)
+            catch(Exception ex)
             {
                 if (attempt <= 3)
                 {
@@ -69,6 +71,7 @@ namespace MakoIoT.Device.Services.AzureIotHub
                     OpenMqttClient(attempt);
                 }
 
+                _logger.Error(ex);
                 throw;
             }
         }

--- a/src/MakoIoT.Device.Services.AzureIotHub/Configuration/AzureIotHubCertConfig.cs
+++ b/src/MakoIoT.Device.Services.AzureIotHub/Configuration/AzureIotHubCertConfig.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace MakoIoT.Device.Services.AzureIotHub.Configuration
+﻿namespace MakoIoT.Device.Services.AzureIotHub.Configuration
 {
     public sealed class AzureIotHubCertConfig
     {

--- a/src/MakoIoT.Device.Services.AzureIotHub/Configuration/AzureIotHubConfig.cs
+++ b/src/MakoIoT.Device.Services.AzureIotHub/Configuration/AzureIotHubConfig.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace MakoIoT.Device.Services.AzureIotHub.Configuration
+﻿namespace MakoIoT.Device.Services.AzureIotHub.Configuration
 {
     public sealed class AzureIotHubConfig
     {


### PR DESCRIPTION
Changed AzureIotHubCommunicationService from internal to public. Refined error handling in the `OpenMqttClient` method to include more detailed exceptions and logging. Also removed unnecessary usings in AzureIotHubConfig and AzureIotHubCertConfig files.