### PR TITLE
Set message type to "application/json" in AzureIoTCommunicationService

### DIFF
--- a/src/MakoIoT.Device.Services.AzureIotHub/AzureIotHubCommunicationService.cs
+++ b/src/MakoIoT.Device.Services.AzureIotHub/AzureIotHubCommunicationService.cs
@@ -91,7 +91,7 @@ namespace MakoIoT.Device.Services.AzureIotHub
         public void Publish(string messageString, string messageType)
         {
             _logger.Information($"AzureIoT publishing message");
-            var isReceived = _client.SendMessage(messageString, null, new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token);
+            var isReceived = _client.SendMessage(messageString, "application/json", new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token);
             if (!isReceived)
             {
                 _logger.Error($"Unable to send message. {messageString}");


### PR DESCRIPTION
Adjusted the Publish function in the AzureIoT communication service. Now, all outgoing messages explicitly declare their type as "application/json". This addition ensures that the Azure IoT Hub correctly processes the message payload.