### PR TITLE
Update 3 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.AzureIotHub.nuspec
+++ b/MakoIoT.Device.Services.AzureIotHub.nuspec
@@ -22,13 +22,13 @@
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
       <dependency id="nanoFramework.Json" version="2.2.117" />
-      <dependency id="nanoFramework.M2Mqtt" version="5.1.126" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.15" />
+      <dependency id="nanoFramework.M2Mqtt" version="5.1.128" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.18" />
       <dependency id="nanoFramework.Runtime.Native" version="1.6.12" />
       <dependency id="nanoFramework.System.Collections" version="1.5.31" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.59" />
       <dependency id="nanoFramework.System.Net" version="1.10.77" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.134" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.136" />
       <dependency id="nanoFramework.System.Text" version="1.2.54" />
       <dependency id="nanoFramework.System.Threading" version="1.1.32" />
     </dependencies>

--- a/src/MakoIoT.Device.Services.AzureIotHub/MakoIoT.Device.Services.AzureIotHub.nfproj
+++ b/src/MakoIoT.Device.Services.AzureIotHub/MakoIoT.Device.Services.AzureIotHub.nfproj
@@ -45,16 +45,16 @@
       <HintPath>..\..\packages\nanoFramework.Json.2.2.117\lib\nanoFramework.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.126.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.126\lib\nanoFramework.M2Mqtt.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.128.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.128\lib\nanoFramework.M2Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.M2Mqtt.Core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.126\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.128\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.15\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.18.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.18\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Native, Version=1.6.12.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -77,8 +77,8 @@
       <HintPath>..\..\packages\nanoFramework.System.Net.1.10.77\lib\System.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.134.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.134\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.136.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.136\lib\System.Net.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.AzureIotHub/packages.config
+++ b/src/MakoIoT.Device.Services.AzureIotHub/packages.config
@@ -5,13 +5,13 @@
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.117" targetFramework="netnano1.0" />
-  <package id="nanoFramework.M2Mqtt" version="5.1.126" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
+  <package id="nanoFramework.M2Mqtt" version="5.1.128" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.6.12" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.10.77" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.134" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.136" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.M2Mqtt from 5.1.126 to 5.1.128</br>Bumps nanoFramework.Runtime.Events from 1.11.15 to 1.11.18</br>Bumps nanoFramework.System.Net.Http from 1.5.134 to 1.5.136</br>
[version update]

### :warning: This is an automated update. :warning:
