### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.AzureIotHub.nuspec
+++ b/MakoIoT.Device.Services.AzureIotHub.nuspec
@@ -18,7 +18,7 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot azure iot azureiothub</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" />
-      <dependency id="nanoFramework.Azure.Devices.Client" version="1.2.59" />
+      <dependency id="nanoFramework.Azure.Devices.Client" version="1.2.62" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
       <dependency id="nanoFramework.Json" version="2.2.152" />

--- a/src/MakoIoT.Device.Services.AzureIotHub/MakoIoT.Device.Services.AzureIotHub.nfproj
+++ b/src/MakoIoT.Device.Services.AzureIotHub/MakoIoT.Device.Services.AzureIotHub.nfproj
@@ -31,8 +31,8 @@
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Azure.Devices.Client, Version=1.2.59.31343, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Azure.Devices.Client.1.2.59\lib\nanoFramework.Azure.Devices.Client.dll</HintPath>
+    <Reference Include="nanoFramework.Azure.Devices.Client, Version=1.2.62.61928, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Azure.Devices.Client.1.2.62\lib\nanoFramework.Azure.Devices.Client.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>

--- a/src/MakoIoT.Device.Services.AzureIotHub/packages.config
+++ b/src/MakoIoT.Device.Services.AzureIotHub/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Azure.Devices.Client" version="1.2.59" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Azure.Devices.Client" version="1.2.62" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.152" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps nanoFramework.Azure.Devices.Client from 1.2.59 to 1.2.62</br>
[version update]

### :warning: This is an automated update. :warning:
